### PR TITLE
Allow setting debug through opts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ var url = require('url'),
 	crypto = require('crypto'),
 	util = require('util'),
 	request = require('request'),
+	colors = require('colors'),
 	debug = require('debug')('appc:pubsub'),
 	EventEmitter = require('events').EventEmitter,
 	environments = {
@@ -109,6 +110,11 @@ function getIPAddresses (callback) {
  */
 function PubSubClient(opts) {
 	opts = opts || {};
+	opts.debug && (debug = function () {
+		var args = Array.prototype.slice.call(arguments);
+		args.unshift('appc:pubsub'.red);
+		console.log.apply(this, args);
+	});
 	var env = opts.env || isRunningInPreproduction() ? 'preproduction' : 'production';
 	this.timeout = opts.timeout || 10000;
 	this.url = opts.url || environments[env] || environments.production;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-pubsub",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "AppC pubsub client library",
   "main": "index.js",
   "scripts": {
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/appcelerator/appc-pubsub",
   "dependencies": {
+    "colors": "^1.1.2",
     "debug": "^2.2.0",
     "internal-ip": "^1.0.1",
     "public-ip": "^1.0.2",


### PR DESCRIPTION
This PR will allow setting debug logs on through opts.

```
var PubSub = require('appc-pubsub'),
    pubsub = new PubSub({
        key: 'MY_KEY',
        secret: 'MY_SECRET',
        debug: true
    });
```