### PR TITLE
Fix case where user objects are being modified prior to save

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -248,6 +248,13 @@ PubSubClient.prototype.publish = function (name, data, immediate) {
 	if (data && typeof(data)!=='object') {
 		throw new Error('data must be an object');
 	}
+	// Clone data before serialization pass so objects are not modified.
+	try {
+		data = JSON.parse(JSON.stringify(data));
+	}
+	catch(e) {
+		throw new Error('data could not be cloned');
+	}
 	this.queue.push({
 		event: name,
 		data: serialize(data, [])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-pubsub",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "AppC pubsub client library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR adds cloning of the data object in pubsub.publish.  Since objects are inherently pass by ref, the scrubbing that takes places on a user doc (and presumably others) is causing password and password_salt to get set to "[HIDDEN]" in preprod when a user logs in since the serialization pass is modifying the doc.

```
data:PRIMARY> db.users.find({ password: /HIDDEN/ }).count()
67
```