### PR TITLE
Add opts flag for exit behavior, handle ECONNRESET/ESOCKETTIMEDOUT codes, bump to 0.0.34

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,9 +15,9 @@ var url = require('url'),
 	fingerprint;
 
 /**
- * utility to determine if we're running in production
+ * utility to determine if we're running in a preproduction env
  */
-function isRunningInPreproduction() {
+function isPreproduction() {
 	return process.env.NODE_ACS_URL &&
 		process.env.NODE_ACS_URL.indexOf('.appctest.com') > 0 ||
 		process.env.NODE_ENV === 'preproduction' ||
@@ -34,11 +34,12 @@ function sha1(value) {
 }
 
 /**
- * get a unique fingerprint for the machine (hashed) which is used for
- * server-side client id tracking
+ * get a unique fingerprint for the machine (hashed) which is used for server-side client id tracking
  */
 function getComputerFingerprint (callback, append) {
-	if (fingerprint) { return callback && callback(null, fingerprint); }
+	if (fingerprint) {
+		return callback && callback(null, fingerprint);
+	}
 	var exec = require('child_process').exec,
 		cmd;
 	switch (process.platform) {
@@ -130,19 +131,29 @@ function PubSubClient(opts) {
 			console.log.apply(this, args);
 		}
 	});
-	var env = isRunningInPreproduction() ? 'preproduction' : opts.env;
-	this.timeout = opts.timeout || 10000;
+
 	// prefer the environment settings over config
-	this.url = env && environments[env] || opts.url || environments.production;
+	var env = opts.env || (isPreproduction() ? 'preproduction' : 'production');
+	this.url = opts.url || environments[env] || environments.production;
+
+	// Require key and secret.
+	this.disabled = opts.disabled;
 	this.key = opts.key;
 	this.secret = opts.secret;
-	this.queue = [];
-	if (!this.key) {
+	if (!this.disabled && !this.key) {
 		throw new Error('missing key');
 	}
-	if (!this.secret) {
+	if (!this.disabled && !this.secret) {
 		throw new Error('missing secret');
 	}
+
+	// Do not exit process on disconnect/close by default.
+	this.exitOnError = opts.exitOnError || false;
+
+	this.timeout = opts.timeout || 10000;
+	this.queue = [];
+
+
 	var self = this;
 	if (opts.newrelic) {
 		var newrelic = opts.newrelic;
@@ -167,10 +178,10 @@ function PubSubClient(opts) {
 			});
 		});
 	}
-	this.disabled = opts.disabled;
 	this.queueSendDelay = opts.queueSendDelay === undefined ? 10 : Math.max(1,+opts.queueSendDelay);
 	this.preferWebSocket = opts.preferWebSocket === undefined ? false : opts.preferWebSocket;
 	getComputerFingerprint();
+
 	// if we prefer web socket transport, then go ahead and connect
 	if (this.preferWebSocket) {
 		this._pendingStart = true;
@@ -312,7 +323,7 @@ PubSubClient.prototype._requeue = function (reason, opts) {
  */
 function createErrorHandler (self, opts) {
 	return function pubsubRequetErrorHandler(err) {
-		if (/^(ETIMEDOUT|ENOTFOUND|ECONNREFUSED)$/.test(err.code)) {
+		if (/^(ETIMEDOUT|ENOTFOUND|ECONNREFUSED|ECONNRESET|ESOCKETTIMEDOUT)$/.test(err.code)) {
 			return self._requeue(err.code, opts);
 		}
 		self.emit('error', err, opts);
@@ -498,7 +509,7 @@ PubSubClient.prototype.close = function() {
 				self._sending = self._connecting = false;
 				self.queue = [];
 				self.close();
-				process.exit();
+				self.exitOnError && process.exit();
 			}, 10000);
 		}
 	}
@@ -514,7 +525,7 @@ PubSubClient.prototype.close = function() {
 			self._shutdown = self._sending = self._connecting = false;
 			self._closed = true; // force close if we haven't received it yet
 			self.close();
-			process.exit();
+			self.exitOnError && process.exit();
 		},5000);
 		return true;
 	}
@@ -530,7 +541,7 @@ PubSubClient.prototype.close = function() {
 				self._shutdown = self._sending = self._connecting = false;
 				self._closed = true; // force close if we haven't received it yet
 				self.close();
-				process.exit();
+				self.exitOnError && process.exit();
 			},5000);
 			return true;
 		}
@@ -567,7 +578,7 @@ PubSubClient.prototype.close = function() {
 	this._closing = false;
 	if (this._pendingExit) {
 		debug('calling process.exit(%d)', this._pendingExitCode);
-		processExit(this._pendingExitCode);
+		this.exitOnError && processExit(this._pendingExitCode);
 	}
 	return this.queue.length;
 };
@@ -707,9 +718,9 @@ PubSubClient.prototype._reconnect = function() {
 				}
 				catch (E) {
 					debug('received error on exit', E.stack);
-					processExit(ec);
+					self.exitOnError && processExit(ec);
 				}
-			} else if (processExit && self._shutdown) {
+			} else if (processExit && self.exitOnError && self._shutdown) {
 				ec = ec === undefined ? 0 : ec;
 				debug('calling process.exit (%d)', ec);
 				processExit(ec);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-pubsub",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "AppC pubsub client library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR...

- introduces support for a opts flag (`exitOnError`) to control whether the client should fire a process.exit when an unrecoverable error occurs as a result of an uncaughtException handling unexpected codes from web response (defaulted to `false`)
- handle two specific error codes seen crashing 360 in the past day or so
- fixes opts handling for env/url to prefer values passed in rather than the known envs (it was just missing the parens on the fallback, seeing `opts.env || isRunningInPreproduction()` as truthy for any `opts.env` value passed in)