### PR TITLE
[PUBSUB-6] Only reject cert hostname mismatches in production environments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -390,7 +390,7 @@ PubSubClient.prototype._runQueue = function (closing) {
 			gzip: true,
 			timeout: this.timeout,
 			followAllRedirects: true,
-			rejectUnauthorized: this.url.indexOf('360-local') < 0
+			rejectUnauthorized: !!~this.url.indexOf(environments.production.split('.').slice(-2).join('.'))
 		},
 		handler = createErrorHandler(this, data);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-pubsub",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "AppC pubsub client library",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "appcelerator"
   ],
   "author": "Jeff Haynie",
-  "license": "LicenseRef-LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/appcelerator/appc-pubsub/issues"
   },


### PR DESCRIPTION
This PR mitigates uncaught exceptions caused by cert hostname/IP mismatches seen in pre-production environments by only forcing rejection in production.  It also fixes an npm warning by switching to the preferred SPDX "SEE LICENSE IN..." expression.