### PR TITLE
[PUBSUB-9] Uncaught exceptions from newrelic cause process to crash

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -161,21 +161,29 @@ function PubSubClient(opts) {
 		this.on('requeue', function (code, opts, retries, length) {
 			var message = code || 'Event requeue';
 			var err = new Error(message);
-			newrelic.noticeError(err, {
-				key: opts.key,
-				url: self.url,
-				fingerprint: fingerprint,
-				retrycount: retries,
-				queuelength: length
-			});
+			try {
+				newrelic.noticeError(err, {
+					key: opts.key,
+					url: self.url,
+					fingerprint: fingerprint,
+					retrycount: retries,
+					queuelength: length
+				});
+			} catch(e) {
+				self.emit('error', e);
+			}
 		});
 		// on a requeue, we are going to send a custom metric to newrelic if configured
 		this.on('connect_error', function (err) {
-			newrelic.noticeError(err, {
-				key: opts.key,
-				url: self.url,
-				fingerprint: fingerprint
-			});
+			try {
+				newrelic.noticeError(err, {
+					key: opts.key,
+					url: self.url,
+					fingerprint: fingerprint
+				});
+			} catch(e) {
+				self.emit('error', e);
+			}
 		});
 	}
 	this.queueSendDelay = opts.queueSendDelay === undefined ? 10 : Math.max(1,+opts.queueSendDelay);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-pubsub",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "AppC pubsub client library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
https://jira.appcelerator.org/browse/PUBSUB-9
This PR wraps newrelic calls in a try/catch since they have a habit of throwing exceptions and we want to handle them as early as possible. The error is then emitted by pubsub for further handling.