### PR TITLE
[PUBSUB-10] emit unauthorized resp, but consume and log errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -399,23 +399,21 @@ PubSubClient.prototype._runQueue = function (closing) {
 				self._sending = false;
 			}
 			debug('received web response', resp && resp.statusCode);
-			if (resp && resp.statusCode!==200) {
+			if (resp && resp.statusCode !== 200) {
 				// an error which isn't a security error, try to push again
-				if (resp && resp.statusCode && !/^(400|401)$/.test(resp.statusCode)) {
+				if (resp.statusCode && !/^(400|401)$/.test(resp.statusCode)) {
 					return self._requeue(resp.statusCode, data);
 				}
 				var err = new Error('invalid response'),
-					name = 'error',
 					closeAfterFire = false;
 				err.code = resp.statusCode;
 				// if 401 that means the apikey, secret is wrong. disable before raising an error
-				if (resp && resp.statusCode === 401) {
+				if (resp.statusCode === 401) {
 					err.message = 'Unauthorized';
-					name = 'unauthorized';
 					closeAfterFire = true;
+					self.emit('unauthorized', err, opts);
 				}
-				self.emit(name, err, opts);
-				debug('error', err);
+				debug('error', err, resp.statusCode, resp.body);
 				if (closeAfterFire) {
 					self.close();
 					self.disabled = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-pubsub",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "AppC pubsub client library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
https://jira.appcelerator.org/browse/PUBSUB-10

This PR logs error status code and response body rather than emitting them, so they don't go uncaught and crash the parent process.  Errors during instancing or initial connection still email and `Unauthorized` still emits and fires closeAfterFire.