### PR TITLE
[PUBSUB-17] remove removeAllListeners

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -592,7 +592,6 @@ PubSubClient.prototype.close = function () {
 		}
 	}
 	this._connected = this._connecting = this._authed = false;
-	this.removeAllListeners();
 	if (this._socket) {
 		this._socket.close();
 		this._socket = null;


### PR DESCRIPTION
Jira: https://jira.appcelerator.org/browse/PUBSUB-17

This PR changes the behavior when the server disconnects the client, the client no longer will removeAllListeners, resolving the issue in which the client would reconnect but would no longer emit to the consumer.


 Node docs warns about bad practices with the usage: https://nodejs.org/api/events.html#events_emitter_removealllisteners_eventname

#### Verification:


0. edit etc/hosts file and add `pubsub-local.cloud.appctest.com`
1. In pubsub server, edit app.js look for the code `!found[key]` and make sure `removeClientWithUUID(key);` is always called by removing the if statement.
2. Run pubsub server locally
3. Run webevent server locally (update config to point to local pubsub server `https://pubsub-local.cloud.appctest.com:8443` in `conf/pubsub.development.js`)
4. Pubsub will terminate the socket connection after about ~10 secs. At this point pubsub client in webevent will reconnect to pubsub-server.
5. Open a browser tab to pubsub-server arrow admin (`https://pubsub-local.cloud.appctest.com:8443/arrow/docs.html?apis/event.html`) and create an event using the docs api with the following data

```
{
	"description": "registry search test",
	"type": "immediate",
	"event": "com.appcelerator.registry.search",
	"data": {"term": "test", "count": 1}
}
```

You should see the message arrive to webevent with the following log `handling event: com.appcelerator.registry.search` even after disconnects.

