### PR TITLE
[PUBSUB-17] add socket connection events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -632,6 +632,7 @@ PubSubClient.prototype.close = function () {
 
 function createDisconnectHandler(self, socket, reconnect) {
 	return function disconnectHandler(reason, message) {
+		self.emit('pubsub:disconnected');
 		debug('disconnect, reason: %s, message: %s, reconnect: %s, pending exit: %s', reason, message, reconnect, !!self._pendingExit);
 		if (self._closing && !self._closed) {
 			debug('already closing, ignore disconnect');
@@ -717,6 +718,7 @@ PubSubClient.prototype._reconnect = function () {
 	let self = this;
 	debug('connecting url=%s', this.url);
 	socket.on('connect', function () {
+		self.emit('pubsub:connected');
 		debug('connected');
 		// we can get multiple notices so we ignore after first
 		if (self._connected) {
@@ -734,6 +736,7 @@ PubSubClient.prototype._reconnect = function () {
 				address: address
 			});
 			socket.on('authenticated', function () {
+				self.emit('pubsub:authenticated');
 				self._authed = true;
 				debug('authenticated');
 				socket.emit('register', toSubArray(self.eventSubscriptions));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-pubsub",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "AppC pubsub client library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Jira: https://jira.appcelerator.org/browse/PUBSUB-17

This PR will add events for the socket connection in which the consumers can handle socket states

#### Verification:


0. edit etc/hosts file and add `pubsub-local.cloud.appctest.com`
1. In pubsub server, edit app.js look for the code `!found[key]` and make sure `removeClientWithUUID(key);` is always called by removing the if statement.
2. Run pubsub server locally
3. Run webevent server locally (update config to point to local pubsub server `https://pubsub-local.cloud.appctest.com:8443` in `conf/pubsub.development.js`)
4. Pubsub will terminate the socket connection after about ~10 secs. At this point pubsub client in webevent will reconnect to pubsub-server.
5. Open a browser tab to pubsub-server arrow admin (`https://pubsub-local.cloud.appctest.com:8443/arrow/docs.html?apis/event.html`) and create an event using the docs api with the following data

```
{
	"description": "registry search test",
	"type": "immediate",
	"event": "com.appcelerator.registry.search",
	"data": {"term": "test", "count": 1}
}
```

You should see the message arrive to webevent with the following log `handling event: com.appcelerator.registry.search` even after disconnects.

