### PR TITLE
[PUBSUB-51] Add consumer helper methods

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -254,6 +254,10 @@ PubSubClient.prototype._parseConfig = function (data) {
  * @return {Boolean} whether the request is authenticated
  */
 PubSubClient.prototype.authenticateWebhook = function (req, res, next) {
+	if (req._authenticatedWebhook) {
+		next && next();
+		return true;
+	}
 	// Make sure the client has consumption enabled
 	if (!this.config.can_consume) {
 		res && res.writeHead(400, { 'Content-Type': 'application/json' });
@@ -301,7 +305,7 @@ PubSubClient.prototype.authenticateWebhook = function (req, res, next) {
  */
 PubSubClient.prototype.handleWebhook = function (req, res) {
 	// Make sure the request has been authenticated
-	if (!req._authenticatedWebhook && !this.authenticateWebhook(req, res)) {
+	if (!this.authenticateWebhook(req, res)) {
 		return;
 	}
 	let event = req.body.event;

--- a/lib/index.js
+++ b/lib/index.js
@@ -236,11 +236,16 @@ PubSubClient.prototype.fetchConfig = function (callback) {
 };
 
 PubSubClient.prototype._parseConfig = function (data) {
-	// Get basic auth creds from the url
-	if (data.can_consume && data.auth_type === 'basic' && data.url) {
-		let details = (url.parse(data.url) || '').auth.split(':');
-		data.auth_user = details[0];
-		data.auth_pass = details[1];
+	if (data.can_consume) {
+		// Extract topic from keys of event map.
+		data.topics = Object.keys(data.events || {});
+
+		// Get basic auth creds from the url
+		if (data.auth_type === 'basic' && data.url) {
+			let details = (url.parse(data.url) || '').auth.split(':');
+			data.auth_user = details[0];
+			data.auth_pass = details[1];
+		}
 	}
 	this.config = data;
 };
@@ -317,7 +322,7 @@ PubSubClient.prototype.handleWebhook = function (req, res) {
 	this.config.topics.forEach(topic => {
 		// Make sure it's not emitted again using the exact name
 		if (topic !== event && new RegExp(topic).test(event)) {
-			this.emit(topic, req.body);
+			this.emit('event:' + topic, req.body);
 		}
 	});
 	res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/lib/index.js
+++ b/lib/index.js
@@ -294,7 +294,7 @@ PubSubClient.prototype.authenticateWebhook = function (req, res, next) {
 		res && res.writeHead(401, { 'Content-Type': 'application/json' });
 		res && res.end(JSON.stringify({
 			success: false,
-			message: 'Unauthorized.'
+			message: 'Unauthorized'
 		}));
 		return false;
 	}
@@ -313,18 +313,19 @@ PubSubClient.prototype.handleWebhook = function (req, res) {
 	if (!this.authenticateWebhook(req, res)) {
 		return;
 	}
+
 	let event = req.body.event;
 	debug('event received', event, req.body);
-	// Emit using the exact event name
-	this.emit(event, req.body);
 
 	// Search for any configured regex matches and emit using those too
 	this.config.topics.forEach(topic => {
 		// Make sure it's not emitted again using the exact name
-		if (topic !== event && new RegExp(topic).test(event)) {
+		if (topic === event || new RegExp(topic).test(event)) {
+			debug('emitting event:' + topic);
 			this.emit('event:' + topic, req.body);
 		}
 	});
+
 	res.writeHead(200, { 'Content-Type': 'application/json' });
 	res.end(JSON.stringify({ success: true }));
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -263,7 +263,7 @@ PubSubClient.prototype.authenticateWebhook = function (req, res, next) {
 		}));
 		return false;
 	}
-	debug('authenticatin webhook using: method =', this.config.auth_type);
+	debug('authenticating webhook using: method =', this.config.auth_type);
 
 	let conf = this.config,
 		headers = req && req.headers || {},
@@ -281,6 +281,7 @@ PubSubClient.prototype.authenticateWebhook = function (req, res, next) {
 
 	// Make sure the request is from pubsub server
 	if (!authenticated) {
+		debug('webhook authentication failed', headers);
 		res && res.writeHead(401, { 'Content-Type': 'application/json' });
 		res && res.end(JSON.stringify({
 			success: false,

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const basicAuth = require('basic-auth');
 const url = require('url');
 const crypto = require('crypto');
 const util = require('util');
@@ -180,9 +181,143 @@ function PubSubClient(opts) {
 		});
 	}
 	getComputerFingerprint();
+	this.fetchConfig();
+	// These functions need the client binding for use as a middleware/route
+	this.authenticateWebhook = this.authenticateWebhook.bind(this);
+	this.handleWebhook = this.handleWebhook.bind(this);
 }
 
 util.inherits(PubSubClient, EventEmitter);
+
+/**
+ * Fetch client config from the server.
+ * @param {Function} callback
+ */
+PubSubClient.prototype.fetchConfig = function (callback) {
+	// some random data to sign for the signature
+	let data = { },
+		opts = {
+			url: url.resolve(this.url, '/api/client/config'),
+			method: 'get',
+			json: data,
+			headers: {
+				'User-Agent': 'Appcelerator PubSub Client/' + version + ' (' + fingerprint + ')',
+				'APIKey': this.key,
+				'APISig': crypto.createHmac('SHA256', this.secret).update(JSON.stringify(data)).digest('base64')
+			},
+			gzip: true,
+			timeout: this.timeout,
+			followAllRedirects: true,
+			rejectUnauthorized: !!~this.url.indexOf(environments.production.split('.').slice(-2).join('.'))
+		};
+	debug('fetching client config');
+	this.config = {};
+	request(opts, function (err, resp, body) {
+		if (err) {
+			return debug('error', err);
+		}
+		let data = body && body[body.key];
+
+		if (!data || resp.statusCode !== 200) {
+			let err = new Error('invalid response');
+			err.code = resp.statusCode;
+			// if 401 that means the apikey, secret is wrong. disable before raising an error
+			if (resp.statusCode === 401) {
+				err.message = 'Unauthorized';
+				this.emit('unauthorized', err, opts);
+			}
+			return debug('error', err, resp.statusCode, resp.body);
+		}
+
+		this._parseConfig(data);
+		debug('got config', this.config);
+		this.emit('configured', this.config);
+	}.bind(this));
+};
+
+PubSubClient.prototype._parseConfig = function (data) {
+	// Get basic auth creds from the url
+	if (data.can_consume && data.auth_type === 'basic' && data.url) {
+		let details = (url.parse(data.url) || '').auth.split(':');
+		data.auth_user = details[0];
+		data.auth_pass = details[1];
+	}
+	this.config = data;
+};
+
+/**
+ * Authenticates a webhook request as being from pubsub server. Can be used as
+ * middleware.
+ * @param {http.ClientRequest} req request object containing auth details
+ * @param {http.ServerResponse} [res] response object for responding with errors
+ * @param {Function} [next] optional callback function for use in middleware
+ * @return {Boolean} whether the request is authenticated
+ */
+PubSubClient.prototype.authenticateWebhook = function (req, res, next) {
+	// Make sure the client has consumption enabled
+	if (!this.config.can_consume) {
+		res && res.writeHead(400, { 'Content-Type': 'application/json' });
+		res && res.end(JSON.stringify({
+			success: false,
+			message: 'This client does not have consumption enabled.'
+		}));
+		return false;
+	}
+	debug('authenticatin webhook using: method =', this.config.auth_type);
+
+	let conf = this.config,
+		headers = req && req.headers || {},
+		user = basicAuth(req),
+		// Validate request using clients authentication method
+		authenticated
+			// Check the basic auth credentials match...
+			= conf.auth_type === 'basic'      ? user.name === conf.auth_user && user.pass === conf.auth_pass
+			// ...or the request has the correct auth token
+			: conf.auth_type === 'token'      ? headers['x-auth-token'] === this.config.auth_token
+			// ...or the signature matches the body signed with the client secret
+			: conf.auth_type === 'key_secret' ? headers['x-signature'] === crypto.createHmac('SHA256', this.secret).update(JSON.stringify(req.body)).digest('hex')
+			// ...otherwise there's no authentication for the client
+			: true;
+
+	// Make sure the request is from pubsub server
+	if (!authenticated) {
+		res && res.writeHead(401, { 'Content-Type': 'application/json' });
+		res && res.end(JSON.stringify({
+			success: false,
+			message: 'Unauthorized.'
+		}));
+		return false;
+	}
+	req._authenticatedWebhook = true;
+	next && next();
+	return true;
+};
+
+/**
+ * Webhook handler route that exposes events using the EventEmitter pattern.
+ * @param {http.ClientRequest} req Request object
+ * @param {http.ServerResponse} res Response object
+ */
+PubSubClient.prototype.handleWebhook = function (req, res) {
+	// Make sure the request has been authenticated
+	if (!req._authenticatedWebhook && !this.authenticateWebhook(req, res)) {
+		return;
+	}
+	let event = req.body.event;
+	debug('event received', event, req.body);
+	// Emit using the exact event name
+	this.emit(event, req.body);
+
+	// Search for any configured regex matches and emit using those too
+	this.config.topics.forEach(topic => {
+		// Make sure it's not emitted again using the exact name
+		if (topic !== event && new RegExp(topic).test(event)) {
+			this.emit(topic, req.body);
+		}
+	});
+	res.writeHead(200, { 'Content-Type': 'application/json' });
+	res.end(JSON.stringify({ success: true }));
+};
 
 /**
  * Returns fingerprint if set, or passes to callback, or generates fingerprint.
@@ -385,6 +520,15 @@ PubSubClient.prototype._send = function (data) {
 let on = PubSubClient.prototype.on;
 PubSubClient.prototype.on = function (name) {
 	debug('on %s', name);
+	// If the topics have been fetched then we can attempt to warn about events
+	// that aren't configured to be received by this client
+	if (this.topics) {
+		let knownEvents = [ 'configured', 'unauthorized' ].concat(this.config.topics || []);
+		// Check for an exact or regex match with a configured topic
+		if (!_.find(knownEvents, event => name === event || name === new RegExp(event))) {
+			debug('Unexpected event' + name + '. This client may not be configured to receive this event.');
+		}
+	}
 	return on.apply(this, arguments);
 };
 

--- a/package.json
+++ b/package.json
@@ -22,20 +22,20 @@
   "dependencies": {
     "basic-auth": "^1.1.0",
     "colors": "^1.1.2",
-    "debug": "^2.6.3",
+    "debug": "^2.6.8",
     "ip": "^1.1.5",
-    "public-ip": "^2.3.3",
+    "public-ip": "^2.3.5",
     "request": "^2.81.0"
   },
   "devDependencies": {
-    "body-parser": "^1.17.1",
-    "express": "^4.15.2",
+    "body-parser": "^1.17.2",
+    "express": "^4.15.4",
     "grunt": "^1.0.1",
-    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-clean": "^1.1.0",
     "grunt-eslint": "^19.0.0",
     "grunt-mocha-istanbul": "^5.0.2",
     "istanbul": "^0.4.5",
-    "mocha": "^3.2.0",
+    "mocha": "^3.5.0",
     "should": "^11.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/appcelerator/appc-pubsub",
   "dependencies": {
+    "basic-auth": "^1.1.0",
     "colors": "^1.1.2",
     "debug": "^2.6.3",
     "ip": "^1.1.5",

--- a/test/webhook.js
+++ b/test/webhook.js
@@ -114,30 +114,30 @@ describe('webhook', function () {
 		assert.ok(res.wasUnauthorized());
 	});
 
-	it('should emit using an exact event name', function (next) {
+	it('should emit using an exact event name', function (done) {
 		let event = 'com.test.event',
 			payload = { event };
 
 		// Set the listener
-		pubsub.on(event, function (data) {
+		pubsub.on('event:' + event, function (data) {
 			// The request body should be passed through
 			assert.equal(data, payload);
-			next();
+			done();
 		});
 		// Spoof an webhook request skipping authentication
 		pubsub.config.auth_type = null;
 		pubsub.handleWebhook(new Request(payload), new Response());
 	});
 
-	it('should emit using a regex topic', function (next) {
+	it('should emit using a regex topic', function (done) {
 		let reEvent = pubsub.config.topics[1],
 			event = reEvent.replace(/\*/g, 'regex'),
 			payload = { event };
 
 		// Set a listener using the regex topic
-		pubsub.on(reEvent, function (data) {
+		pubsub.on('event:' + reEvent, function (data) {
 			assert.equal(data, payload);
-			next();
+			done();
 		});
 		pubsub.handleWebhook(new Request(payload), new Response());
 	});

--- a/test/webhook.js
+++ b/test/webhook.js
@@ -15,10 +15,10 @@ pubsub.updateConfig({
 	auth_type: 'basic',
 	url: 'http://un:pw@localhost:8080.com',
 	can_consume: true,
-	topics: [
-		'com.test.event',
-		'com.test.topic.*'
-	]
+	events: {
+		'com.test.event': null,
+		'com.test.topic.*': null
+	}
 });
 
 describe('webhook', function () {

--- a/test/webhook.js
+++ b/test/webhook.js
@@ -1,0 +1,167 @@
+const assert = require('assert');
+const crypto = require('crypto');
+const PubSub = require('../');
+
+// Valid client details should be used
+let key = '',
+	secret = '',
+	pubsub;
+
+/**
+ * Mock response object to capture response details.
+ */
+function Response() {
+}
+Response.prototype.writeHead = function (code, headers) {
+	this.code = code;
+	this.headers = headers;
+};
+Response.prototype.write = function (str) {
+	this.body = str;
+};
+Response.prototype.end = function () {
+	this.ended = true;
+};
+Response.prototype.wasUnauthorized = function () {
+	return this.code === 401 && this.ended;
+};
+
+/**
+ * Mock request object
+ * @param {Object} body the request body
+ * @param {Object} headers the request headers
+ */
+function Request(body, headers) {
+	this.headers = headers || {};
+	this.body = body || {};
+}
+
+describe('webhook', function () {
+
+	// Create a new client and wait for the config to be fetched
+	before('new client', function (next) {
+		pubsub = new PubSub({
+			key: key,
+			secret: secret
+		});
+		pubsub.on('configured', () => next());
+	});
+
+	it('should validate basic auth credentials', function () {
+		// Set the config and parse the basic auth details
+		pubsub._parseConfig(Object.assign(pubsub.config, {
+			auth_type: 'basic',
+			url: 'http://un:pw@localhost:8080.com'
+		}));
+		let success = false,
+			res = new Response(),
+			req = new Request({}, {
+				authorization: 'Basic ' + new Buffer('un:pw').toString('base64')
+			});
+
+		// Test the return value and that the callback is called for middleware use
+		let authed = pubsub.authenticateWebhook(req, res, () => success = true);
+		// Both should have succeeded
+		assert.ok(success && authed);
+
+		// Make sure incorrect credentials are handled
+		req.headers.authorization = 'Basic ' + new Buffer('un2:pw2').toString('base64');
+		success = false;
+		authed = pubsub.authenticateWebhook(req, res, () => success = true);
+		// The return value should be false and the callback should not have been called
+		assert.equal(success || authed, false);
+		// If a response object is given then an unauthorized response should be sent
+		assert.ok(res.wasUnauthorized());
+	});
+
+	it('should validate auth token', function () {
+		// Set the config and parse the basic auth details
+		pubsub._parseConfig(Object.assign(pubsub.config, {
+			auth_type: 'token',
+			url: 'http://localhost:8080.com',
+			auth_token: 'test-token'
+		}));
+		let success = false,
+			res = new Response(),
+			req = new Request({}, {
+				'x-auth-token': 'test-token'
+			});
+
+		// Correct creds
+		let authed = pubsub.authenticateWebhook(req, res, () => success = true);
+		assert.ok(success && authed);
+
+		// Incorrect creds
+		req.headers['x-auth-token'] = 'not-this';
+		success = false;
+		authed = pubsub.authenticateWebhook(req, res, () => success = true);
+		assert.equal(success || authed, false);
+		assert.ok(res.wasUnauthorized());
+	});
+
+	it('should validate key/secret signature', function () {
+		// set the config and parse the basic auth details
+		pubsub._parseConfig(Object.assign(pubsub.config, {
+			auth_type: 'key_secret',
+			url: 'http://localhost:8080.com',
+			auth_token: 'test-token'
+		}));
+		let success = false,
+			res = new Response(),
+			body = { event: 'com.test.event' },
+			req = new Request(body, {
+				'x-signature': crypto.createHmac('SHA256', pubsub.secret).update(JSON.stringify(body)).digest('hex')
+			});
+
+		// Correct creds
+		let authed = pubsub.authenticateWebhook(req, res, () => success = true);
+		assert.ok(success && authed);
+
+		// Incorrect creds
+		req.headers['x-signature'] = 'not-this';
+		success = false;
+		authed = pubsub.authenticateWebhook(req, res, () => success = true);
+		assert.equal(success || authed, false);
+		assert.ok(res.wasUnauthorized());
+	});
+
+	it('should emit using an exact event name', function (next) {
+		let event = 'com.test.event',
+			payload = { event };
+
+		// Set the listener
+		pubsub.on(event, function (data) {
+			// The request body should be passed through
+			assert.equal(data, payload);
+			next();
+		});
+		// Spoof an webhook request skipping authentication
+		pubsub.config.auth_type = null;
+		pubsub.handleWebhook(new Request(payload), new Response());
+	});
+
+	it('should emit using a regex topic', function (next) {
+		let reEvent = 'com.test.topic.*',
+			event = 'com.test.topic.regex',
+			payload = { event };
+
+		// The regex topic needs to be in the clients configured topics
+		pubsub.config.topics.push(reEvent);
+		pubsub.on(reEvent, function (data) {
+			assert.equal(data, payload);
+			next();
+		});
+		pubsub.handleWebhook(new Request(payload), new Response());
+	});
+
+	it('should not receive an unrelated event', function () {
+		let event = 'com.unrelated.event',
+			payload = { event };
+
+		// Set the listener
+		pubsub.on('com.different.event', function (data) {
+			assert.fail('Listener should not have been called');
+		});
+		pubsub.handleWebhook(new Request(payload), new Response());
+	});
+});


### PR DESCRIPTION
https://techweb.axway.com/jira/browse/PUBSUB-51

This PR adds two methods to the pubsub client:
- `authenticateWebhook(req, res, next)`
This function authenticates that a request has come from pubsub server, using the clients configured authentication method. The parameters `res` and `next` are optional for use as middleware, where it will send a 401 response for unauthorized requests.

- `handleWebhook(req, res)`
A route handler that will run authentication and wire up events to be listened to using the EventEmitter pattern.

The functions must be called after the request body has been parsed.
The client config has to be fetched from the server when the client is started, and a `configured` event is emitted once that's done.
The clients topic list will be checked when adding a listener, and a warning shown if the event is not expected to received by the client. The warnings are only shown once the topic list has been fetched.

## Verification
This must be run against a local pubsub server with appcelerator/appc-pubsub-server/pull/23.

1. 
    - Create a simple node server that uses the `authenticateWebhook` function, (snippet below). 
    - Create a new client on the server pointing to it (s'why it needs to be local server). 
    - For each auth type publish an event the client is configured to receive, and make sure the events are accepted. You'll need to restart the client or call `pubsub.fetchConfig()` after changing the auth type on the server.
    - Manually make a requests to the endpoint without any authentication and make sure you get 401 response.
```javascript
// as middleware
app.use('/webhook', pubsub.authenticateWebhook);
app.post('/webhook', function(req, res, next) {
	// or manually called
	if (!pubsub.authenticateWebhook(req, res)) {
		return;
	}
	console.dir(req.body);
	res.json(req.body);
});
```
2.
    - Make sure the client is configured to receive an exact match, `com.test.event` and a regex topic that includes the exact match `com.test.*`, and a unique regex topic `com.different.*`.
    - Subscribe to some events using the `handleWebhook` function and EventEmitter pattern (snippet below).
    - Make sure the authentication is performed as above by the route handler.
    - Publish a `com.test.event` event and make sure the listener for `com.test.event` and `com.test.*` are fired.
   - Publish an event using `com.different.event` and make sure the listener for only `com.different.*` is fired.
```javascript
app.post('/webhook', pubsub.handleWebhook);
// wait until the config has been fetched an set a listener for each subscribed topic
pubsub.on('configured', function (config) {
	config.topics.forEach(function (topic) {
		pubsub.on(topic, data => console.log(event, JSON.stringify(data)));
	});
});
```