### PR TITLE
remove debug override and colors module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,16 +104,6 @@ function getComputerFingerprint(callback, append) {
  */
 function PubSubClient(opts) {
 	opts = opts || {};
-	opts.debug && (debug = function () {
-		let args = Array.prototype.slice.call(arguments);
-		if (args[0] && !!~args[0].indexOf('%')) {
-			let result = util.format.apply(util.format, args);
-			console.log('appc:pubsub'.red, result);
-		} else {
-			args.unshift('appc:pubsub'.red);
-			console.log.apply(this, args);
-		}
-	});
 
 	// prefer the environment settings over config
 	let env = opts.env || (isPreproduction() ? 'preproduction' : 'production');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-pubsub",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "AppC pubsub client library",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,6 @@
   "homepage": "https://github.com/appcelerator/appc-pubsub",
   "dependencies": {
     "basic-auth": "^1.1.0",
-    "colors": "^1.1.2",
     "debug": "^2.6.8",
     "ip": "^1.1.5",
     "public-ip": "^2.3.5",


### PR DESCRIPTION
This PR will remove confusing use of debug when the opts passed to pubsub contain a `debug:true` flag, the client overrides debug and logs to console using `colors` module

No functionality is lost as the common way to get debug logs is to specify: `DEBUG=appc:pubsub`
