### PR TITLE
Correct and optimize darwin fingerprint retrieval

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@ function getComputerFingerprint(callback, append) {
 	switch (process.platform) {
 		case 'darwin':
 			// serial number + uuid is a good fingerprint
-			cmd = 'ioreg -l | awk \'/IOPlatformSerialNumber/ { print $4 }\' | sed s/\\"//g && ioreg -rd1 -c IOPlatformExpertDevice |  awk \'/IOPlatformUUID/ { print $3; }\' | sed s/\\"//g;';
+			cmd = 'ioreg -c IOPlatformExpertDevice -d 2 | awk -F\\" \'/IOPlatformSerialNumber|IOPlatformUUID/{ print $(NF-1) }\';';
 			debug('running:', cmd);
 			return exec(cmd, function (err, stdout) {
 				if (err) {


### PR DESCRIPTION
This PR will correct an issue retrieving the fingerprint on `darwin` machines which was causing the fingerprinting to run over and over causing CPU churn on every published event.

I changed it to make better use of `ioreg` and `awk` in order to complete in two commands, rather than six, so it's much more efficient in the first place.

