### PR TITLE
[PUBSUB-76] Only emit events for the posted topic, improved validation on event receipt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-- '6'
+- '8'
 before_script:
-- npm cache clean
 - npm run lint

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ function isPreproduction() {
 
 /**
  * Returns sha1 digested value.
- * @param {String} value value to digest 
+ * @param {String} value value to digest
  * @returns {String} digested value
  */
 function sha1(value) {
@@ -297,33 +297,33 @@ PubSubClient.prototype.handleWebhook = function (req, res) {
  * @returns {Boolean} true if event matched topics
  */
 PubSubClient.prototype.isSubscribedTopic = function (name, topics) {
-	// Event names are prefixed, so strip it
+	// Event names are prefixed, so strip it.
 	name = name.replace('event:', '');
-	// Add internal events since they will be emitted
+	// Add internal events since they will be emitted.
 	let validTopics = [ 'configured', 'unauthorized' ].concat(topics || this.config.topics || []);
 	return !!validTopics.find(topic => {
 		// Name matches topic
 		if (topic === name) {
 			return true;
 		}
-		// Fall out if exact match missed and topic does not have wildcard
+		// Fall out if exact match missed and topic does not have wildcard.
 		if (!topic.includes('*')) {
 			return false;
 		}
 		let eventSegments = name.split('.');
 		let topicSegments = topic.split('.');
-		// Fall out if topic is not double-splatted and segment counts do not match
+		// Fall out if topic is not double-splatted and segment counts do not match.
 		if (!topic.includes('**') && eventSegments.length !== topicSegments.length) {
 			return false;
 		}
-		// Check if name matches topic segment checks 
+		// Check if name matches topic segment checks.
 		return topicSegments.reduce(function (m, segment, i) {
 			return m && (
 				// segment matched 
 				segment === eventSegments[i]
 				// segment was wildcarded
 				|| segment === '*'
-				// segment was terminus and double-splatted 
+				// segment was terminus and double-splatted
 				|| (segment === '**' && i === topicSegments.length - 1)
 			);
 		}, true);

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ let environments = {
 	preproduction: 'https://pubsub-preprod.cloud.appctest.com'
 };
 let fingerprint;
+let pendingChecks = [];
 
 /**
  * Checks process.env flags to determine if env is preproduction or developement.
@@ -22,13 +23,18 @@ let fingerprint;
  */
 function isPreproduction() {
 	return process.env.NODE_ACS_URL
-		&& process.env.NODE_ACS_URL.indexOf('.appctest.com') > 0
+		&& process.env.NODE_ACS_URL.includes('.appctest.com')
 		|| process.env.NODE_ENV === 'preproduction'
 		|| process.env.APPC_ENV === 'preproduction'
 		|| process.env.NODE_ENV === 'development'
 		|| process.env.APPC_ENV === 'development';
 }
 
+/**
+ * Returns sha1 digested value.
+ * @param {String} value value to digest 
+ * @returns {String} digested value
+ */
 function sha1(value) {
 	return crypto
 		.createHash('sha1')
@@ -120,10 +126,14 @@ function PubSubClient(opts) {
 	this.disabled = opts.disabled;
 	this.key = opts.key;
 	this.secret = opts.secret;
-	if (!this.disabled && !this.key) {
+
+	if (this.disabled) {
+		return;
+	}
+	if (!this.key) {
 		throw new Error('missing key');
 	}
-	if (!this.disabled && !this.secret) {
+	if (!this.secret) {
 		throw new Error('missing secret');
 	}
 
@@ -137,13 +147,6 @@ function PubSubClient(opts) {
 }
 
 util.inherits(PubSubClient, EventEmitter);
-
-/**
- * Stub deprecated close function.
- */
-PubSubClient.prototype.close = function () {
-	debug('pubsub.close function has been deprecated. Websocket connections are no longer supported.');
-};
 
 /**
  * Fetch client config from the server.
@@ -164,7 +167,7 @@ PubSubClient.prototype.fetchConfig = function () {
 			gzip: true,
 			timeout: this.timeout,
 			followAllRedirects: true,
-			rejectUnauthorized: !!~this.url.indexOf(environments.production.split('.').slice(-2).join('.'))
+			rejectUnauthorized: this.url.includes(environments.production.split('.').slice(-2).join('.'))
 		};
 	debug('fetching client config');
 	this.config = {};
@@ -186,8 +189,10 @@ PubSubClient.prototype.fetchConfig = function () {
 		}
 
 		this._parseConfig(data);
-		debug('got config', this.config);
+
+		this.on('configured', () => pendingChecks.forEach(this._validateTopic.bind(this)));
 		this.emit('configured', this.config);
+		debug('got config', this.config);
 	}.bind(this));
 };
 
@@ -207,8 +212,7 @@ PubSubClient.prototype._parseConfig = function (data) {
 };
 
 /**
- * Authenticates a webhook request as being from pubsub server. Can be used as
- * middleware.
+ * Authenticates a webhook request as being from pubsub server. Can be used as middleware.
  * @param {http.ClientRequest} req request object containing auth details
  * @param {http.ServerResponse} [res] response object for responding with errors
  * @param {Function} [next] optional callback function for use in middleware
@@ -273,25 +277,57 @@ PubSubClient.prototype.handleWebhook = function (req, res) {
 		return;
 	}
 
-	let event = req.body.event;
-	debug('event received', event, req.body);
+	let topic = req.body.topic;
+	debug('event received', topic, req.body);
 
 	// Search for any configured regex matches and emit using those too
-	this.config.topics.forEach(topic => {
-		// Only emit the event on topics that are exact or pattern matches
-		let subscribedTopic = topic === event;
-		if (!subscribedTopic && topic.includes('*')) {
-			let eventSegments = event.split('.');
-			subscribedTopic = topic.split('.').reduce((m, segment, i) => m && (segment === '*' || segment === eventSegments[i]));
-		}
-		if (subscribedTopic) {
-			debug('emitting event:' + topic);
-			this.emit('event:' + topic, req.body);
-		}
-	});
+	if (this.isSubscribedTopic(topic)) {
+		debug('emitting event:' + topic);
+		this.emit('event:' + topic, req.body);
+	}
 
 	res.writeHead(200, { 'Content-Type': 'application/json' });
 	res.end(JSON.stringify({ success: true }));
+};
+
+/**
+ * Validates that event name is in client's subscribed topics (or provided topic list).
+ * @param {String} name topic/event name
+ * @param {Array} topics (optional) set of topics to validate against, defaults to this.config.topics
+ * @returns {Boolean} true if event matched topics
+ */
+PubSubClient.prototype.isSubscribedTopic = function (name, topics) {
+	// Event names are prefixed, so strip it
+	name = name.replace('event:', '');
+	// Add internal events since they will be emitted
+	let validTopics = [ 'configured', 'unauthorized' ].concat(topics || this.config.topics || []);
+	return !!validTopics.find(topic => {
+		// Name matches topic
+		if (topic === name) {
+			return true;
+		}
+		// Fall out if exact match missed and topic does not have wildcard
+		if (!topic.includes('*')) {
+			return false;
+		}
+		let eventSegments = name.split('.');
+		let topicSegments = topic.split('.');
+		// Fall out if topic is not double-splatted and segment counts do not match
+		if (!topic.includes('**') && eventSegments.length !== topicSegments.length) {
+			return false;
+		}
+		// Check if name matches topic segment checks 
+		return topicSegments.reduce(function (m, segment, i) {
+			return m && (
+				// segment matched 
+				segment === eventSegments[i]
+				// segment was wildcarded
+				|| segment === '*'
+				// segment was terminus and double-splatted 
+				|| (segment === '**' && i === topicSegments.length - 1)
+			);
+		}, true);
+	});
 };
 
 /**
@@ -333,7 +369,7 @@ function serialize(obj, seen) {
 		} else if (value instanceof RegExp) {
 			obj[key] = value.source;
 		} else if (t === 'object') {
-			if (seen.indexOf(value) !== -1) {
+			if (seen.includes(value)) {
 				value = '[Circular]';
 			} else {
 				seen.push(value);
@@ -440,7 +476,7 @@ PubSubClient.prototype._send = function (data) {
 		gzip: true,
 		timeout: this.timeout,
 		followAllRedirects: true,
-		rejectUnauthorized: !!~this.url.indexOf(environments.production.split('.').slice(-2).join('.'))
+		rejectUnauthorized: this.url.includes(environments.production.split('.').slice(-2).join('.'))
 	};
 
 	try {
@@ -496,14 +532,25 @@ PubSubClient.prototype.on = function (name) {
 	debug('on', name);
 	// If the topics have been fetched then we can attempt to warn about events
 	// that aren't configured to be received by this client
-	if (this.config.topics) {
-		let knownEvents = [ 'configured', 'unauthorized' ].concat(this.config.topics || []);
-		// Check for an exact or regex match with a configured topic
-		if (knownEvents.find(event => name === event || name === new RegExp(event))) {
-			debug('Unexpected event', name, ': client not configured to receive this event');
-		}
+	if (!this.configued) {
+		pendingChecks.push(name);
+	} else {
+		this._validateTopic(name);
 	}
 	return on.apply(this, arguments);
+};
+
+PubSubClient.prototype._validateTopic = function (name) {
+	if (!this.isSubscribedTopic(name)) {
+		debug('Unexpected event', name, ': client not configured to receive this event');
+	}
+};
+
+/**
+ * Stub deprecated close function.
+ */
+PubSubClient.prototype.close = function () {
+	debug('pubsub.close function has been deprecated. Websocket connections are no longer supported.');
 };
 
 module.exports = PubSubClient;

--- a/lib/index.js
+++ b/lib/index.js
@@ -319,7 +319,7 @@ PubSubClient.prototype.isSubscribedTopic = function (name, topics) {
 		// Check if name matches topic segment checks.
 		return topicSegments.reduce(function (m, segment, i) {
 			return m && (
-				// segment matched 
+				// segment matched
 				segment === eventSegments[i]
 				// segment was wildcarded
 				|| segment === '*'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-pubsub",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "AppC pubsub client library",
   "main": "index.js",
   "scripts": {

--- a/test/validation.js
+++ b/test/validation.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const assert = require('assert');
+const helper = require('./_helper');
+
+// Valid client details should be used
+let pubsub = new helper.createMockConfigClient({
+	key: 'key',
+	secret: 'secret'
+});
+
+pubsub.updateConfig({
+	url: 'http://un:pw@localhost:8080.com',
+	can_consume: true,
+	events: {
+		'com.test.event': null,
+		'com.test.topic.*': null,
+		'com.test.*.interior': null,
+		'com.splatted.**': null
+	}
+});
+
+describe('validation', function () {
+
+	it('should validate exact event name matches', function () {
+		assert.ok(pubsub.isSubscribedTopic('com.test.event'));
+	});
+
+	it('should validate events matching wildcard terminus segment', function () {
+		assert.ok(pubsub.isSubscribedTopic('com.test.topic.anything'));
+	});
+
+	it('should validate events matching wildcard interior segment', function () {
+		assert.ok(pubsub.isSubscribedTopic('com.test.anything.interior'));
+	});
+
+	it('should validate events matching double-splatted topic', function () {
+		assert.ok(pubsub.isSubscribedTopic('com.splatted.shortName'));
+		assert.ok(pubsub.isSubscribedTopic('com.splatted.a.much.longer.event.name'));
+	});
+
+	it('should not validate unsubscribed event topics', function () {
+		assert.equal(pubsub.isSubscribedTopic('com.invalid.event'), false);
+	});
+
+	it('should not validate descendant topics', function () {
+		assert.equal(pubsub.isSubscribedTopic('com.test.event.descendant'), false);
+		assert.equal(pubsub.isSubscribedTopic('com.test.topic.wildcard.descendant'), false);
+		assert.equal(pubsub.isSubscribedTopic('com.test.wildcard.interior.descendant'), false);
+	});
+});

--- a/test/webhook.js
+++ b/test/webhook.js
@@ -132,7 +132,6 @@ describe('webhook', function () {
 		pubsub.handleWebhook(new Request(payload), new Response());
 	});
 
-
 	it('should not receive an unrelated event', function () {
 		let topic = 'com.unrelated.event',
 			payload = { topic };


### PR DESCRIPTION
Two key changes here...

1. We no longer emit based on matching the event to the client's subscribed topics.  appc-pubsub-server will post a topic in the payload sent to the webhook and will now emit that topic exactly if it's configured as subscribed.
1. The validation helper method is now a "public" property on am instanced client.  The server will use a disabled client's subscribed topic logic to validate what clients should receive a published event. (I.e., let's not duplicate this logic.)

Any project currently using a 1.X client should upgrade to 1.2.0 once published.