### PR TITLE
[PUBSUB-80] Get subscribed topic

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -281,7 +281,7 @@ PubSubClient.prototype.handleWebhook = function (req, res) {
 	debug('event received', topic, req.body);
 
 	// Search for any configured regex matches and emit using those too
-	if (this.isSubscribedTopic(topic)) {
+	if (this.getSubscribedTopic(topic)) {
 		debug('emitting event:' + topic);
 		this.emit('event:' + topic, req.body);
 	}
@@ -296,25 +296,25 @@ PubSubClient.prototype.handleWebhook = function (req, res) {
  * @param {Array} topics (optional) set of topics to validate against, defaults to this.config.topics
  * @returns {Boolean} true if event matched topics
  */
-PubSubClient.prototype.isSubscribedTopic = function (name, topics) {
+PubSubClient.prototype.getSubscribedTopic = function (name, topics) {
 	// Event names are prefixed, so strip it.
 	name = name.replace('event:', '');
 	// Add internal events since they will be emitted.
 	let validTopics = [ 'configured', 'unauthorized' ].concat(topics || this.config.topics || []);
-	return !!validTopics.find(topic => {
+	return validTopics.find(topic => {
 		// Name matches topic
 		if (topic === name) {
-			return true;
+			return topic;
 		}
 		// Fall out if exact match missed and topic does not have wildcard.
 		if (!topic.includes('*')) {
-			return false;
+			return null;
 		}
 		let eventSegments = name.split('.');
 		let topicSegments = topic.split('.');
 		// Fall out if topic is not double-splatted and segment counts do not match.
 		if (!topic.includes('**') && eventSegments.length !== topicSegments.length) {
-			return false;
+			return null;
 		}
 		// Check if name matches topic segment checks.
 		return topicSegments.reduce(function (m, segment, i) {
@@ -327,7 +327,7 @@ PubSubClient.prototype.isSubscribedTopic = function (name, topics) {
 				|| (segment === '**' && i === topicSegments.length - 1)
 			);
 		}, true);
-	});
+	}) || null;
 };
 
 /**
@@ -541,7 +541,7 @@ PubSubClient.prototype.on = function (name) {
 };
 
 PubSubClient.prototype._validateTopic = function (name) {
-	if (!this.isSubscribedTopic(name)) {
+	if (!this.getSubscribedTopic(name)) {
 		debug('Unexpected event', name, ': client not configured to receive this event');
 	}
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-pubsub",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "AppC pubsub client library",
   "main": "index.js",
   "scripts": {

--- a/test/validation.js
+++ b/test/validation.js
@@ -9,43 +9,55 @@ let pubsub = new helper.createMockConfigClient({
 	secret: 'secret'
 });
 
+let events = {
+	'com.test.event': null,
+	'com.test.topic.*': null,
+	'com.test.*.interior': null,
+	'com.splatted.**': null
+};
+let topics = Object.keys(events);
+
 pubsub.updateConfig({
 	url: 'http://un:pw@localhost:8080.com',
 	can_consume: true,
-	events: {
-		'com.test.event': null,
-		'com.test.topic.*': null,
-		'com.test.*.interior': null,
-		'com.splatted.**': null
-	}
+	events
 });
 
 describe('validation', function () {
 
 	it('should validate exact event name matches', function () {
 		assert.equal(pubsub.getSubscribedTopic('com.test.event'), 'com.test.event');
+		assert.equal(pubsub.getSubscribedTopic('com.test.event', topics), 'com.test.event');
 	});
 
 	it('should validate events matching wildcard terminus segment', function () {
 		assert.equal(pubsub.getSubscribedTopic('com.test.topic.anything'), 'com.test.topic.*');
+		assert.equal(pubsub.getSubscribedTopic('com.test.topic.anything', topics), 'com.test.topic.*');
 	});
 
 	it('should validate events matching wildcard interior segment', function () {
 		assert.equal(pubsub.getSubscribedTopic('com.test.anything.interior'), 'com.test.*.interior');
+		assert.equal(pubsub.getSubscribedTopic('com.test.anything.interior', topics), 'com.test.*.interior');
 	});
 
 	it('should validate events matching double-splatted topic', function () {
 		assert.equal(pubsub.getSubscribedTopic('com.splatted.shortName'), 'com.splatted.**');
 		assert.equal(pubsub.getSubscribedTopic('com.splatted.a.much.longer.event.name'), 'com.splatted.**');
+		assert.equal(pubsub.getSubscribedTopic('com.splatted.shortName', topics), 'com.splatted.**');
+		assert.equal(pubsub.getSubscribedTopic('com.splatted.a.much.longer.event.name', topics), 'com.splatted.**');
 	});
 
 	it('should not validate unsubscribed event topics', function () {
 		assert.equal(pubsub.getSubscribedTopic('com.invalid.event'), null);
+		assert.equal(pubsub.getSubscribedTopic('com.invalid.event', topics), null);
 	});
 
 	it('should not validate descendant topics', function () {
 		assert.equal(pubsub.getSubscribedTopic('com.test.event.descendant'), null);
 		assert.equal(pubsub.getSubscribedTopic('com.test.topic.wildcard.descendant'), null);
 		assert.equal(pubsub.getSubscribedTopic('com.test.wildcard.interior.descendant'), null);
+		assert.equal(pubsub.getSubscribedTopic('com.test.event.descendant', topics), null);
+		assert.equal(pubsub.getSubscribedTopic('com.test.topic.wildcard.descendant', topics), null);
+		assert.equal(pubsub.getSubscribedTopic('com.test.wildcard.interior.descendant', topics), null);
 	});
 });

--- a/test/validation.js
+++ b/test/validation.js
@@ -23,29 +23,29 @@ pubsub.updateConfig({
 describe('validation', function () {
 
 	it('should validate exact event name matches', function () {
-		assert.ok(pubsub.isSubscribedTopic('com.test.event'));
+		assert.equal(pubsub.getSubscribedTopic('com.test.event'), 'com.test.event');
 	});
 
 	it('should validate events matching wildcard terminus segment', function () {
-		assert.ok(pubsub.isSubscribedTopic('com.test.topic.anything'));
+		assert.equal(pubsub.getSubscribedTopic('com.test.topic.anything'), 'com.test.topic.*');
 	});
 
 	it('should validate events matching wildcard interior segment', function () {
-		assert.ok(pubsub.isSubscribedTopic('com.test.anything.interior'));
+		assert.equal(pubsub.getSubscribedTopic('com.test.anything.interior'), 'com.test.*.interior');
 	});
 
 	it('should validate events matching double-splatted topic', function () {
-		assert.ok(pubsub.isSubscribedTopic('com.splatted.shortName'));
-		assert.ok(pubsub.isSubscribedTopic('com.splatted.a.much.longer.event.name'));
+		assert.equal(pubsub.getSubscribedTopic('com.splatted.shortName'), 'com.splatted.**');
+		assert.equal(pubsub.getSubscribedTopic('com.splatted.a.much.longer.event.name'), 'com.splatted.**');
 	});
 
 	it('should not validate unsubscribed event topics', function () {
-		assert.equal(pubsub.isSubscribedTopic('com.invalid.event'), false);
+		assert.equal(pubsub.getSubscribedTopic('com.invalid.event'), null);
 	});
 
 	it('should not validate descendant topics', function () {
-		assert.equal(pubsub.isSubscribedTopic('com.test.event.descendant'), false);
-		assert.equal(pubsub.isSubscribedTopic('com.test.topic.wildcard.descendant'), false);
-		assert.equal(pubsub.isSubscribedTopic('com.test.wildcard.interior.descendant'), false);
+		assert.equal(pubsub.getSubscribedTopic('com.test.event.descendant'), null);
+		assert.equal(pubsub.getSubscribedTopic('com.test.topic.wildcard.descendant'), null);
+		assert.equal(pubsub.getSubscribedTopic('com.test.wildcard.interior.descendant'), null);
 	});
 });


### PR DESCRIPTION
https://techweb.axway.com/jira/browse/PUBSUB-80

Minor change from 1.2.0...

The `isSubscribedTopic` function was refactored to `getSubscribedTopic` which returns the first matching subscribed topic for a given client (or null), rather than a boolean if the topic was found.

Also added validation tests for cases where the topic list is passed in.

This bumps to a 1.3.0, but there's no functional changes for existing clients.

