### PR TITLE
Bump axios version in order to fix security issue CVE-2022-0155.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -559,11 +559,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
-      "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
+      "version": "0.25.0",
+      "resolved": "http://registry.ecd.axway.int:8081/artifactory/api/npm/registry-npm/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha1-NJz7sxMxqbRFMZB5F2Co01sJPgo=",
       "requires": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.7"
       }
     },
     "balanced-match": {
@@ -1446,9 +1446,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
+      "version": "1.14.8",
+      "resolved": "http://registry.ecd.axway.int:8081/artifactory/api/npm/registry-npm/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha1-AWmW+5oRoQBWY5ixxoOTN9e/qPw="
     },
     "foreground-child": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/appcelerator/appc-pubsub",
   "dependencies": {
-    "axios": "0.23.0",
+    "axios": "0.25.0",
     "basic-auth": "2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
 `follow-redirects` security issue [CVE-2022-0155](https://github.com/advisories/GHSA-74fj-2j2h-c42q)
its a dependency of axios [https://github.com/slackapi/bolt-js/issues/1270](https://github.com/slackapi/bolt-js/issues/1270) used in appc-pubsub [https://github.com/appcelerator/appc-pubsub/blob/master/package.json#L21](https://github.com/appcelerator/appc-pubsub/blob/master/package.json#L21) It seems fixed with [axios@0.25.0](https://github.com/axios/axios/releases/tag/v0.25.0)