### PR TITLE
1.7.0 - [PUBSUB-335] Default timestamp on publish if not passed in options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -246,7 +246,7 @@ PubSubClient.prototype.handleWebhook = function (req, res) {
  * @param {Object} data optional event payload or undefined/null if no event data
  * @param {Object} options the options object
  */
-PubSubClient.prototype.publish = function (event, data, options) {
+PubSubClient.prototype.publish = function (event, data = {}, options = {}) {
 	if (this.disabled) {
 		return;
 	}
@@ -257,7 +257,7 @@ PubSubClient.prototype.publish = function (event, data, options) {
 	if (Buffer.byteLength(event) > 255) {
 		throw new Error('name length must be less than 255 bytes');
 	}
-	if (data && typeof data !== 'object') {
+	if (typeof data !== 'object') {
 		throw new Error('data must be an object');
 	}
 	// Clone data before serialization pass so objects are not modified.
@@ -265,6 +265,15 @@ PubSubClient.prototype.publish = function (event, data, options) {
 		data = JSON.parse(JSON.stringify(data || {}));
 	} catch (e) {
 		throw new Error('data could not be parsed');
+	}
+
+	if (typeof options !== 'object') {
+		throw new Error('options must be an object');
+	}
+
+	// Default timestamp if not provided.
+	if (!options.timestamp) {
+		options.timestamp = Date.now();
 	}
 
 	// Generate identifier and send event.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appc-pubsub",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "appc-pubsub",
-      "version": "1.6.2",
+      "version": "1.7.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "axios": "0.26.0",
@@ -16,7 +16,7 @@
         "eslint": "8.9.0",
         "eslint-config-axway": "7.0.0",
         "eslint-plugin-mocha": "10.0.3",
-        "mocha": "9.2.0",
+        "mocha": "9.2.1",
         "nyc": "15.1.0",
         "should": "13.2.3"
       },
@@ -2860,9 +2860,9 @@
       "dev": true
     },
     "node_modules/mocha": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
-      "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.1.tgz",
+      "integrity": "sha512-T7uscqjJVS46Pq1XDXyo9Uvey9gd3huT/DD9cYBb4K2Xc/vbKRPUWK067bxDQRK0yIz6Jxk73IrnimvASzBNAQ==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -6337,9 +6337,9 @@
       "dev": true
     },
     "mocha": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
-      "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.1.tgz",
+      "integrity": "sha512-T7uscqjJVS46Pq1XDXyo9Uvey9gd3huT/DD9cYBb4K2Xc/vbKRPUWK067bxDQRK0yIz6Jxk73IrnimvASzBNAQ==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-pubsub",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "Amplify Platform PubSub client",
   "main": "index.js",
   "scripts": {
@@ -25,7 +25,7 @@
     "eslint": "8.9.0",
     "eslint-config-axway": "7.0.0",
     "eslint-plugin-mocha": "10.0.3",
-    "mocha": "9.2.0",
+    "mocha": "9.2.1",
     "nyc": "15.1.0",
     "should": "13.2.3"
   },


### PR DESCRIPTION
https://jira.axway.com/browse/PUBSUB-335

This PR introduces a minor behavior change to default the timestamp in the `options` argument of published events if not passed in the `client.publish` call's options. With debug enabled, the log entry for the `_send` call will now show the defaulted timestamp in options.

```
appc:pubsub _send my.awesome.event-1645762322518 {
  data: { some_prop: true, ... },
  event: 'my.awesome.event',
  options: { timestamp: 1645762322518 }
} 
```
