### PR TITLE
[PUBSUB-382] Make webhook functions async

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,55 +74,58 @@ inherits(PubSubClient, EventEmitter);
  * @param {Function} [next] optional callback function for use in middleware
  * @return {Boolean} whether the request is authenticated
  */
-PubSubClient.prototype.authenticateWebhook = function (req, res, next) {
+PubSubClient.prototype.authenticateWebhook = async function (req, res, next) {
 	if (req._authenticatedWebhook) {
 		next && next();
 		return true;
 	}
 
-	this._getBody(req, res, function (body) {
-		// Make sure the client has consumption enabled
-		if (!this.config.can_consume) {
-			res && res.writeHead(400, { 'Content-Type': 'application/json' });
-			res && res.end(JSON.stringify({
-				success: false,
-				message: 'This client does not have consumption enabled.'
-			}));
-			return false;
-		}
-		debug.info('authenticating webhook using: method =', this.config.auth_type);
+	const body = await this._getBody(req, res);
+	if (!body) {
+		return false;
+	}
 
-		let conf = this.config,
-			headers = req && req.headers || {},
-			creds = auth(req),
-			// Validate request using clients authentication method
-			authenticated
-				// Check the basic auth credentials match...
-				= conf.auth_type === 'basic'
-					? creds.name === conf.auth_user && creds.pass === conf.auth_pass
-					// ...or the request has the correct auth token
-					: conf.auth_type === 'token'
-						? headers['x-auth-token'] === this.config.auth_token
-						// ...or the signature matches the body signed with the client secret
-						: conf.auth_type === 'key_secret'
-							? headers['x-signature'] === createHmac('SHA256', this.secret).update(JSON.stringify(body)).digest('hex')
-							// ...otherwise there's no authentication for the client
-							: true;
+	// Make sure the client has consumption enabled
+	if (!this.config.can_consume) {
+		res && res.writeHead(400, { 'Content-Type': 'application/json' });
+		res && res.end(JSON.stringify({
+			success: false,
+			message: 'This client does not have consumption enabled.'
+		}));
+		return false;
+	}
+	debug.info('authenticating webhook using: method =', this.config.auth_type);
 
-		// Make sure the request is from pubsub server
-		if (!authenticated) {
-			debug.error('webhook authentication failed', headers);
-			res && res.writeHead(401, { 'Content-Type': 'application/json' });
-			res && res.end(JSON.stringify({
-				success: false,
-				message: 'Unauthorized'
-			}));
-			return false;
-		}
-		req._authenticatedWebhook = true;
-		next && next();
-		return true;
-	});
+	let conf = this.config,
+		headers = req && req.headers || {},
+		creds = auth(req),
+		// Validate request using clients authentication method
+		authenticated
+			// Check the basic auth credentials match...
+			= conf.auth_type === 'basic'
+				? creds.name === conf.auth_user && creds.pass === conf.auth_pass
+				// ...or the request has the correct auth token
+				: conf.auth_type === 'token'
+					? headers['x-auth-token'] === this.config.auth_token
+					// ...or the signature matches the body signed with the client secret
+					: conf.auth_type === 'key_secret'
+						? headers['x-signature'] === createHmac('SHA256', this.secret).update(JSON.stringify(body)).digest('hex')
+						// ...otherwise there's no authentication for the client
+						: true;
+
+	// Make sure the request is from pubsub server
+	if (!authenticated) {
+		debug.error('webhook authentication failed', headers);
+		res && res.writeHead(401, { 'Content-Type': 'application/json' });
+		res && res.end(JSON.stringify({
+			success: false,
+			message: 'Unauthorized'
+		}));
+		return false;
+	}
+	req._authenticatedWebhook = true;
+	next && next();
+	return true;
 };
 
 /**
@@ -223,25 +226,27 @@ PubSubClient.prototype.hasSubscribedTopic = function (name, topics) {
  * @param {http.ClientRequest} req Request object
  * @param {http.ServerResponse} res Response object
  */
-PubSubClient.prototype.handleWebhook = function (req, res) {
+PubSubClient.prototype.handleWebhook = async function (req, res) {
 	// Make sure the request has been authenticated
-	if (!this.authenticateWebhook(req, res)) {
+	if (!await this.authenticateWebhook(req, res)) {
 		return;
 	}
 
-	this._getBody(req, res, function (body) {
-		let topic = body.topic;
-		debug.info('event received', topic, body);
+	const body = await this._getBody(req, res);
+	if (!body) {
+		return;
+	}
+	let topic = body.topic;
+	debug.info('event received', topic, body);
 
-		// Search for any configured regex matches and emit using those too
-		if (this.hasSubscribedTopic(topic)) {
-			debug.info('emitting event:' + topic);
-			this.emit('event:' + topic, body);
-		}
+	// Search for any configured regex matches and emit using those too
+	if (this.hasSubscribedTopic(topic)) {
+		debug.info('emitting event:' + topic);
+		this.emit('event:' + topic, body);
+	}
 
-		res.writeHead(200, { 'Content-Type': 'application/json' });
-		res.end(JSON.stringify({ success: true }));
-	});
+	res.writeHead(200, { 'Content-Type': 'application/json' });
+	res.end(JSON.stringify({ success: true }));
 };
 
 /**
@@ -293,43 +298,47 @@ PubSubClient.prototype.publish = function (event, data = {}, options = {}) {
  * @param {Object} req Request object
  * @param {Object} res Response object
  * @param {Function} cb Callback function
+ * @returns {Promise<Object>} Request body
  */
-PubSubClient.prototype._getBody = function (req, res, cb) {
+PubSubClient.prototype._getBody = function (req, res) {
 	const self = this;
 
 	// If the body is already parsed return it.
 	if (req.body || req._pubsubBody) {
-		cb.call(self, req.body || req._pubsubBody);
-		return;
+		return req.body || req._pubsubBody;
 	}
 
 	// Expect JSON body.
 	if (req.headers['content-type'] !== 'application/json') {
 		this._sendBodyError(req, res);
-		return;
+		return null;
 	}
 
 	const length = req.headers['content-length'];
 	let data = '';
 
-	// Read the request body falling out if it's too long.
-	req.on('data', req._pubsubDataListener = function (d) {
-		data += d.toString();
-		if (data.length > length) {
-			return self._sendBodyError(req, res);
-		}
-	});
+	return new Promise(function (resolve) {
+		// Read the request body falling out if it's too long.
+		req.on('data', req._pubsubDataListener = function (d) {
+			data += d.toString();
+			if (data.length > length) {
+				self._sendBodyError(req, res);
+				return resolve(null);
+			}
+		});
 
-	// Once the request has ended parse the body.
-	req.on('end', req._pubsubEndListener = function () {
-		let parsed;
-		try {
-			parsed = JSON.parse(data);
-		} catch (err) {
-			return self._sendBodyError(req, res);
-		}
-		req._pubsubBody = parsed;
-		cb.call(self, parsed);
+		// Once the request has ended parse the body.
+		req.on('end', req._pubsubEndListener = function () {
+			let parsed;
+			try {
+				parsed = JSON.parse(data);
+			} catch (err) {
+				self._sendBodyError(req, res);
+				return resolve(null);
+			}
+			req._pubsubBody = parsed;
+			resolve(parsed);
+		});
 	});
 };
 

--- a/test/_helper.js
+++ b/test/_helper.js
@@ -1,4 +1,5 @@
 'use strict';
+const EventEmitter = require('events');
 
 const util = require('util');
 const PubSub = require('../');
@@ -33,32 +34,36 @@ exports.createMockConfigClient = function (config) {
 
 /**
  * Mock request object
- * @param {Object} body the request body
- * @param {Object} headers the request headers
  */
-function Request(body, headers) {
-	this.headers = headers || {};
-	this.body = body || {};
+class Request extends EventEmitter {
+	/**
+	 * @param {Object} body the request body
+	 * @param {Object} headers the request headers
+	 */
+	constructor (body, headers) {
+		super();
+		this.headers = headers || {};
+		this.body = body;
+	}
 }
 exports.Request = Request;
 
 /**
  * Mock response object to capture response details.
  */
-function Response() {
+class Response {
+	writeHead(code, headers) {
+		this.code = code;
+		this.headers = headers;
+	}
+	write(str) {
+		this.body = str;
+	}
+	end() {
+		this.ended = true;
+	}
+	wasUnauthorized() {
+		return this.code === 401 && this.ended;
+	}
 }
 exports.Response = Response;
-
-Response.prototype.writeHead = function (code, headers) {
-	this.code = code;
-	this.headers = headers;
-};
-Response.prototype.write = function (str) {
-	this.body = str;
-};
-Response.prototype.end = function () {
-	this.ended = true;
-};
-Response.prototype.wasUnauthorized = function () {
-	return this.code === 401 && this.ended;
-};


### PR DESCRIPTION
https://jira.axway.com/browse/PUBSUB-382

Before https://github.com/appcelerator/appc-pubsub/pull/49 authenticateWebhook and handleWebhook were synchronous and authenticateWebhook would return true/false. With the body parsing they are both asynchronous now so the true/false value can be returned without affecting use as a middleware.

## Verification
Are the tests happy again, and can you receive events as expected. Particularly when the client does it's own body parsing.