### PR TITLE
Use UPPERCASE for HTTP methods

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -238,7 +238,7 @@ class PubSubClient extends EventEmitter {
 	 * @returns {*}
 	 */
 	async update(id, data = {}, options = {}) {
-		debug.info('patch', id);
+		logger.info('patch', id);
 		if (!id) {
 			throw new Error('required event id');
 		}
@@ -280,7 +280,7 @@ class PubSubClient extends EventEmitter {
 		const body = JSON.stringify(data);
 		const opts = {
 			url: url.href,
-			method: 'post',
+			method: 'POST',
 			headers: this.#makeHeaders(body),
 			body,
 			signal: AbortSignal.timeout(this.#timeout)
@@ -288,7 +288,7 @@ class PubSubClient extends EventEmitter {
 
 		if (data.id) {
 			opts.url += `/${data.id}`;
-			opts.method = 'patch';
+			opts.method = 'PATCH';
 		}
 
 		try {


### PR DESCRIPTION
This PR fixes a bug happening in certain services when not using UPPER case for HTTP methods.
This PR fixes a bug with referencing `debug`, instead of `logger`.